### PR TITLE
Fix cost formatting in calculateTotal

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,12 +263,13 @@
 
         function calculateTotal(itemNum) {
             const quantity = parseFloat(document.getElementById(`quantity${itemNum}`).value) || 0; // Convert to number
-            const cost = parseFloat(document.getElementById(`cost${itemNum}`).value) || 0; // Convert to number
+            const costInput = document.getElementById(`cost${itemNum}`); // Reference to cost input field
+            const cost = parseFloat(costInput.value) || 0; // Convert to number
             const formattedCost = cost.toFixed(2); // Format cost to .00
             const total = (quantity * cost).toFixed(2); // Format total to .00
 
-            document.getElementById(`cost${itemNum}`).innerText = `${formattedCost}`; //cost
-            document.getElementById(`total${itemNum}`).innerText = `Total: ${total}`; //total
+            costInput.value = formattedCost; // cost
+            document.getElementById(`total${itemNum}`).innerText = `Total: ${total}`; // total
             calculateGrandTotal();
         }
 


### PR DESCRIPTION
## Summary
- Ensure cost inputs are updated via their value property and formatted to two decimals

## Testing
- `node test.js` (jsdom simulation of total and grand-total calculations)

------
https://chatgpt.com/codex/tasks/task_e_689d55676c788321a64a687dd85b0a14