### PR TITLE
Ensure numeric types for Excel export

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,15 +460,15 @@
             // Fill items and their totals in the Excel
             for (let i = 1; i <= itemCount; i++) {
                 const item = document.getElementById(`item${i}`).value || '';
-                const quantity = document.getElementById(`quantity${i}`).value || 0;
-                const cost = document.getElementById(`cost${i}`).value || 0;
+                const quantity = parseInt(document.getElementById(`quantity${i}`).value) || 0;
+                const cost = parseFloat(document.getElementById(`cost${i}`).value) || 0;
                 const total = quantity * cost;
 
                 XLSX.utils.sheet_add_aoa(worksheet, [[item, quantity, cost, total]], { origin: `A${i + 12}` }); // Start filling from row 12
             }
 
             // Add grand total to the Excel as a value
-            const grandTotal = document.getElementById('grandTotal').innerText || 0;
+            const grandTotal = parseFloat(document.getElementById('grandTotal').innerText) || 0;
             XLSX.utils.sheet_add_aoa(worksheet, [[, , "Grand Total:", grandTotal]], { origin: `C${itemCount + 12}` }); // Grand Total at column D
 
             // Save the filled Excel


### PR DESCRIPTION
## Summary
- parse quantity, cost, and grand total to numeric values before writing to Excel

## Testing
- `node - <<'NODE'
const XLSX = require('xlsx');
const worksheet = XLSX.utils.aoa_to_sheet([]);
const quantity = parseInt('3');
const cost = parseFloat('5.67');
const total = quantity * cost;
XLSX.utils.sheet_add_aoa(worksheet, [["Item", quantity, cost, total]], { origin: "A1" });
const grandTotal = parseFloat('12.34');
XLSX.utils.sheet_add_aoa(worksheet, [[, , "Grand Total:", grandTotal]], { origin: "C2" });
const wb = XLSX.utils.book_new();
XLSX.utils.book_append_sheet(wb, worksheet, "Sheet1");
XLSX.writeFile(wb, "test.xlsx");
const read = XLSX.readFile("test.xlsx");
const ws = read.Sheets["Sheet1"];
console.log('B1', ws["B1"], 'C1', ws["C1"], 'D1', ws["D1"], 'F2', ws["F2"]);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689d5707f4148321a83bad20c729d9a4