### PR TITLE
Refactor event handling in purchase order form

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,25 +164,25 @@
                 <label for="item1">Item 1:</label><br>
                 <input type="text" id="item1" name="item[]" placeholder="Item name" maxlength="26" required>
                 <div class="details-container" id="details-container1"></div>
-                <input type="number" id="quantity1" name="quantity[]" placeholder="Quantity" min="1" oninput="calculateTotal(1)">
-                <input type="number" id="cost1" name="cost[]" placeholder="Price per unit" min="0.01" step="0.01" oninput="calculateTotal(1)">
+                <input type="number" id="quantity1" name="quantity[]" placeholder="Quantity" min="1">
+                <input type="number" id="cost1" name="cost[]" placeholder="Price per unit" min="0.01" step="0.01">
                 <br><span id="total1" class="total-price">Total: 0.00</span>
-                <button type="button" onclick="addDetail(1)" class="button-addDetails">+</button>
+                <button type="button" id="addDetail1" class="button-addDetails">+</button>
             </div>
         </form>
         
 
         <h3>Grand Total: <span id="grandTotal">0.00</span></h3>
 
-        <button type="button" onclick="addItem()">Add More Item</button>
-        <button type="button" onclick="removeItem()" class="button-remove">Remove Item</button>
-        <button type="button" onclick="GeneratePDF()" class="button-PDF">Generate PDF</button>
+        <button type="button" id="addItemBtn">Add More Item</button>
+        <button type="button" id="removeItemBtn" class="button-remove">Remove Item</button>
+        <button type="button" id="generatePdfBtn" class="button-PDF">Generate PDF</button>
         <p class="error" id="errorMsg">Maximum of 11 items allowed.</p>
         <!--<p>Testing by adam</p>-->
 
         <!-- Fill up excel upload and button
         <input type="file" id="templateFile" accept=".xlsx" required>
-        <input type="button" value="Fill Excel" onclick="fillExcel()">
+        <input type="button" value="Fill Excel">
         -->
 
     </div>
@@ -190,6 +190,13 @@
     <script>
         let itemCount = 1;
         const maxItems = 11;
+
+        document.getElementById('addItemBtn').addEventListener('click', addItem);
+        document.getElementById('removeItemBtn').addEventListener('click', removeItem);
+        document.getElementById('generatePdfBtn').addEventListener('click', GeneratePDF);
+        document.getElementById('addDetail1').addEventListener('click', () => addDetail(1));
+        document.getElementById('quantity1').addEventListener('input', () => calculateTotal(1));
+        document.getElementById('cost1').addEventListener('input', () => calculateTotal(1));
 
         function addItem() {
         if (itemCount < maxItems) {
@@ -201,13 +208,17 @@
                     <label for="item${itemCount}">Item ${itemCount}:</label><br>
                     <input type="text" id="item${itemCount}" name="item[]" placeholder="Item name" maxlength="26" required>
                     <div class="details-container" id="details-container${itemCount}"></div> <!-- Add details container -->
-                    <input type="number" id="quantity${itemCount}" name="quantity[]" placeholder="Quantity" min="1" oninput="calculateTotal(${itemCount})">
-                    <input type="number" id="cost${itemCount}" name="cost[]" placeholder="Price per unit" min="0.01" step="0.01" oninput="calculateTotal(${itemCount})">
+                    <input type="number" id="quantity${itemCount}" name="quantity[]" placeholder="Quantity" min="1">
+                    <input type="number" id="cost${itemCount}" name="cost[]" placeholder="Price per unit" min="0.01" step="0.01">
                     <br><span id="total${itemCount}" class="total-price">Total: 0.00</span>
-                    <button type="button" onclick="addDetail(${itemCount})" class="button-addDetails">+</button>
+                    <button type="button" class="button-addDetails" data-item="${itemCount}">+</button>
                     `;
                 form.appendChild(newItem);
-            } 
+
+                document.getElementById(`quantity${itemCount}`).addEventListener('input', () => calculateTotal(itemCount));
+                document.getElementById(`cost${itemCount}`).addEventListener('input', () => calculateTotal(itemCount));
+                newItem.querySelector('.button-addDetails').addEventListener('click', () => addDetail(itemCount));
+            }
             else {
                 document.getElementById('errorMsg').style.display = 'block';
             }
@@ -241,10 +252,11 @@
     
             detailDiv.innerHTML = `
             <input type="text" placeholder="Detail" maxlength="26">
-            <button type="button" onclick="removeDetail(this)" class="button-removeDetails">Remove</button>
+            <button type="button" class="button-removeDetails">Remove</button>
             `;
-    
+
             detailsContainer.appendChild(detailDiv);
+            detailDiv.querySelector('button').addEventListener('click', (e) => removeDetail(e.target));
         }
 
         function removeDetail(button) {


### PR DESCRIPTION
## Summary
- remove inline `onclick`/`oninput` attributes from form
- wire up item, detail, and total handlers with `addEventListener`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d5705565083218be286b95678eb5c